### PR TITLE
nashc: Fix Trustonic TEE decryption and Keymaster HAL in TWRP

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -95,6 +95,7 @@ PLATFORM_VERSION_LAST_STABLE := $(PLATFORM_VERSION)
 TW_INCLUDE_CRYPTO := true
 TW_INCLUDE_CRYPTO_FBE := true
 TW_INCLUDE_FBE_METADATA_DECRYPT := true
+TW_USE_FSCRYPT_POLICY := 2
 TW_PREPARE_DATA_MEDIA_EARLY := true
 
 # AVB
@@ -144,7 +145,7 @@ TW_EXCLUDE_APEX := true
 TW_OVERRIDE_SYSTEM_PROPS := "ro.build.version.sdk"
 
 # Version/Maintainer
-include $(DEVICE_PATH)/version.mk
+-include $(DEVICE_PATH)/version.mk
 
 # Debugging Configs
 TWRP_INCLUDE_LOGCAT := true

--- a/recovery/root/init.recovery.mt6785.rc
+++ b/recovery/root/init.recovery.mt6785.rc
@@ -4,6 +4,7 @@ import /init.recovery.trustonic.rc
 
 on init
     symlink /dev/block/platform/bootdevice /dev/block/bootdevice
+    symlink /mnt/vendor/persist /persist
     export LD_LIBRARY_PATH /system/lib64:/vendor/lib64:/vendor/lib64/hw
     setprop ro.boot.build.security_patch 2099-12-31
 

--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -1,4 +1,4 @@
-# Initial fstab file, need more improvement
+# Recovery fstab file for Realme 8 (nashc)
 
 # Main Partitions erofs
 system          /system         erofs       ro      wait,logical
@@ -14,6 +14,7 @@ product         /product        ext4        ro      wait,logical,avb=vbmeta_syst
 odm             /odm            ext4        ro      wait,logical,first_stage_mount
 
 # Other Partitions
-/dev/block/by-name/metadata     /metadata   ext4                noatime,nosuid,nodev,discard                                                                                     wait,check,formattable,first_stage_mount
-/dev/block/by-name/userdata     /data       f2fs                noatime,nosuid,nodev,discard,noflush_merge,fsync_mode=nobarrier,reserve_root=134217,resgid=1065,inlinecrypt       wait,check,formattable,quota,reservedsize=128m,latemount,resize,checkpoint=fs,fileencryption=aes-256-xts:aes-256-cts:v2+inlinecrypt_optimized,keydirectory=/metadata/vold/metadata_encryption,fsverity
-/dev/block/by-name/misc         /misc       emmc                defaults                                                                                                         defaults
+/dev/block/by-name/metadata     /metadata            ext4                noatime,nosuid,nodev,discard                                                                                     wait,check,formattable,first_stage_mount
+/dev/block/by-name/userdata     /data                f2fs                noatime,nosuid,nodev,discard,noflush_merge,fsync_mode=nobarrier,reserve_root=134217,resgid=1065,inlinecrypt       wait,check,formattable,quota,reservedsize=128m,latemount,resize,checkpoint=fs,fileencryption=aes-256-xts:aes-256-cts:v2+inlinecrypt_optimized,keydirectory=/metadata/vold/metadata_encryption,fsverity
+/dev/block/by-name/persist      /mnt/vendor/persist  ext4                noatime,nosuid,nodev,barrier=1                                                                                   wait,check,first_stage_mount
+/dev/block/by-name/misc         /misc                emmc                defaults                                                                                                         defaults

--- a/recovery/root/system/etc/vintf/manifest.xml
+++ b/recovery/root/system/etc/vintf/manifest.xml
@@ -4,6 +4,46 @@
 -->
 <manifest version="4.0" type="framework">
     <hal format="hidl">
+        <name>android.hardware.keymaster</name>
+        <transport>hwbinder</transport>
+        <version>4.0</version>
+        <interface>
+            <name>IKeymasterDevice</name>
+            <instance>default</instance>
+        </interface>
+        <fqname>@4.0::IKeymasterDevice/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.gatekeeper</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IGatekeeper</name>
+            <instance>default</instance>
+        </interface>
+        <fqname>@1.0::IGatekeeper/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.trustonic.tee</name>
+        <transport>hwbinder</transport>
+        <version>1.1</version>
+        <interface>
+            <name>ITeeService</name>
+            <instance>default</instance>
+        </interface>
+        <fqname>@1.1::ITeeService/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.mediatek.hardware.keymaster_attestation</name>
+        <transport>hwbinder</transport>
+        <version>1.1</version>
+        <interface>
+            <name>IKeymasterDevice</name>
+            <instance>default</instance>
+        </interface>
+        <fqname>@1.1::IKeymasterDevice/default</fqname>
+    </hal>
+    <hal format="hidl">
         <name>android.frameworks.displayservice</name>
         <transport>hwbinder</transport>
         <version>1.0</version>

--- a/version.mk
+++ b/version.mk
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2026 The TeamWin Recovery Project
+# SPDX-License-Identifier: Apache-2.0
+#
+
+TW_DEVICE_VERSION := 12.1-nashc


### PR DESCRIPTION
## Summary of Fixes for TWRP Decryption on Realme 8 (MT6785)

This PR resolves the decryption failure when lockscreen (PIN/Pattern/Password) is enabled on Realme UI 2 / 3:

1. **VINTF Manifest (manifest.xml):** Added missing HIDL HAL declarations for android.hardware.keymaster@4.0, android.hardware.gatekeeper@1.0, vendor.trustonic.tee@1.1, and vendor.mediatek.hardware.keymaster_attestation@1.1 so hwservicemanager allows the crypto engine to bind to Keymaster.
2. **Mounting persist (recovery.fstab):** Added /dev/block/by-name/persist to /mnt/vendor/persist with first_stage_mount so mcDriverDaemon (Trustonic TEE) finds mcRegistry without crashing on startup.
3. **FBE v2 Crypto Policy (BoardConfig.mk):** Added TW_USE_FSCRYPT_POLICY := 2 to properly support Android 11/12 v2 encryption policies.
4. **Init Script (init.recovery.mt6785.rc):** Added symlink /mnt/vendor/persist -> /persist.